### PR TITLE
RRule output form new CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "webpack": "3.5.1",
     "webpack-dev-server": "2.7.1",
     "webpack-manifest-plugin": "1.2.1",
-    "whatwg-fetch": "2.0.3"
+    "whatwg-fetch": "2.0.3",
+    "react-autosize-textarea": "latest"
   },
   "peerDependencies": {
     "react": ">=0.14",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "promise": "8.0.1",
     "prop-types": "^15.6.0",
     "react": "^15.6.1",
+    "react-autosize-textarea": "^0.4.9",
     "react-copy-to-clipboard": "^5.0.1",
     "react-datetime": "^2.10.3",
     "react-dev-utils": "^3.1.0",
@@ -78,8 +79,7 @@
     "webpack": "3.5.1",
     "webpack-dev-server": "2.7.1",
     "webpack-manifest-plugin": "1.2.1",
-    "whatwg-fetch": "2.0.3",
-    "react-autosize-textarea": "latest"
+    "whatwg-fetch": "2.0.3"
   },
   "peerDependencies": {
     "react": ">=0.14",

--- a/src/lib/components/RRule/index.js
+++ b/src/lib/components/RRule/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import CopyToClipboard from 'react-copy-to-clipboard';
+import TextareaAutosize from 'react-autosize-textarea';
 
 const RRule = ({ rrule, isCopied, handleCopy }) => (
   <div className="px-3">
@@ -15,12 +16,11 @@ const RRule = ({ rrule, isCopied, handleCopy }) => (
 
       </div>
       <div className="col-sm-8">
-        <div className="code">
-          <code>
-            {rrule}
-          </code>
-        </div>
-        <div className="code-fader" />
+        <TextareaAutosize
+          className="form-control"
+          value={rrule}
+          readOnly
+        />
       </div>
 
       <div className="col-sm-2">

--- a/src/lib/components/RRule/index.js
+++ b/src/lib/components/RRule/index.js
@@ -17,7 +17,7 @@ const RRule = ({ rrule, isCopied, handleCopy }) => (
       </div>
       <div className="col-sm-8">
         <TextareaAutosize
-          className="form-control"
+          className={`form-control rrule ${isCopied ? 'rrule-copied' : 'rrule-not-copied'}`}
           value={rrule}
           readOnly
         />

--- a/src/lib/components/Repeat/Monthly/On.js
+++ b/src/lib/components/Repeat/Monthly/On.js
@@ -11,7 +11,7 @@ const RepeatMonthlyOn = ({
   const isActive = mode === 'on';
 
   return (
-    <div className="form-group row d-flex align-items-sm-center">
+    <div className={`form-group row d-flex align-items-sm-center ${!isActive && 'opacity-50'}`}>
       <div className="col-sm-1 offset-sm-2">
         {hasMoreModes && (
           <input

--- a/src/lib/components/Repeat/Monthly/OnThe.js
+++ b/src/lib/components/Repeat/Monthly/OnThe.js
@@ -12,7 +12,7 @@ const RepeatMonthlyOnThe = ({
   const isActive = mode === 'on the';
 
   return (
-    <div className="form-group row d-flex align-items-sm-center">
+    <div className={`form-group row d-flex align-items-sm-center ${!isActive && 'opacity-50'}`}>
       <div className="col-sm-1 offset-sm-2">
         {hasMoreModes && (
           <input

--- a/src/lib/components/Repeat/Yearly/On.js
+++ b/src/lib/components/Repeat/Yearly/On.js
@@ -15,7 +15,7 @@ const RepeatYearlyOn = ({
   const isActive = mode === 'on';
 
   return (
-    <div className="form-group row d-flex align-items-sm-center">
+    <div className={`form-group row d-flex align-items-sm-center ${!isActive && 'opacity-50'}`}>
       <div className="col-sm-1 offset-sm-2">
 
         {hasMoreModes && (

--- a/src/lib/components/Repeat/Yearly/OnThe.js
+++ b/src/lib/components/Repeat/Yearly/OnThe.js
@@ -12,7 +12,7 @@ const RepeatYearlyOnThe = ({
   const isActive = mode === 'on the';
 
   return (
-    <div className="form-group row d-flex align-items-sm-center">
+    <div className={`form-group row d-flex align-items-sm-center ${!isActive && 'opacity-50'}`}>
       <div className="col-sm-1 offset-sm-2">
         {hasMoreModes && (
           <input

--- a/src/lib/styles/index.css
+++ b/src/lib/styles/index.css
@@ -10,17 +10,3 @@ body {
 ::-webkit-scrollbar {
   display: none;
 }
-
-.code {
-  position: relative;
-  overflow-x: scroll;
-}
-
-.code-fader {
-  top: 0;
-  right: 0;
-  width: 20%;
-  height: 100%;
-  background: linear-gradient(to right, rgba(255,255,255,0), rgba(255,255,255,1));
-  position: absolute;
-}

--- a/src/lib/styles/index.css
+++ b/src/lib/styles/index.css
@@ -22,17 +22,17 @@ body {
 }
 
 .rrule-not-copied {
-  color: #2a7dd9;
+  color: #222;
 }
 
 .rrule-not-copied:focus {
-  color: #2a7dd9;
+  color: #222;
 }
 
 .rrule-copied {
-  color: #666;
+  color: #888;
 }
 
 .rrule-copied:focus {
-  color: #666;
+  color: #888;
 }

--- a/src/lib/styles/index.css
+++ b/src/lib/styles/index.css
@@ -22,11 +22,11 @@ body {
 }
 
 .rrule-not-copied {
-  color: #2b81d9;
+  color: #2a7dd9;
 }
 
 .rrule-not-copied:focus {
-  color: #2b81d9;
+  color: #2a7dd9;
 }
 
 .rrule-copied {

--- a/src/lib/styles/index.css
+++ b/src/lib/styles/index.css
@@ -14,3 +14,25 @@ body {
 .opacity-50 {
   opacity: 0.5;
 }
+
+.rrule {
+  background-color: #ffecef;
+  font-size: 80%;
+  font-family: SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace;
+}
+
+.rrule-not-copied {
+  color: #2b81d9;
+}
+
+.rrule-not-copied:focus {
+  color: #2b81d9;
+}
+
+.rrule-copied {
+  color: #666;
+}
+
+.rrule-copied:focus {
+  color: #666;
+}

--- a/src/lib/styles/index.css
+++ b/src/lib/styles/index.css
@@ -10,3 +10,7 @@ body {
 ::-webkit-scrollbar {
   display: none;
 }
+
+.opacity-50 {
+  opacity: 0.5;
+}


### PR DESCRIPTION
RRule is no longer hidden and scrollable and is shown in its full shape.
Output form now automatically changes its size (height) based on the length of RRule string.

Not active modes have now 50% opacity.

<img width="547" alt="screenshot 2017-11-01 at 03 39 45 pm" src="https://user-images.githubusercontent.com/27646234/32280077-ee7c5644-bf1a-11e7-8de6-295a46ad8c84.png">

