### PR TITLE
Add Start form component for setting dtstart property in RRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ class ControlledRender extends Component {
 | **yearly** | `string` | If `'on'` provided, only choosing a particular day of a month is available, if `'on the'` is provided, you have ability to choose for example 'fourth Wednesday of February' |
 | **monthly** | `string` | If `'on'` provided, only choosing a particular day of a month is available, if `'on the'` is provided, you have ability to choose for example 'fourth Wednesday' |
 | **end** | `array` of `string` | You can optionally choose if you want to show ending options `'Never'`, `'After'`, `'On date'`. You can pass for example `['Never', 'On date']` if you want to show only options for ending never or on a particular date without showint 'After' option. |
+| **hideStart** | `boolean` | If `true` start date form is not rendered |
 | **hideEnd** | `boolean` | If `true` ending form is not rendered |
 | **hideError** | `boolean` | If `true` error alert is not rendered |
 | **weekStartsOnSunday** | `boolean` | If set to `true`, weeks starts on Sunday (both for views and RRule string). |

--- a/src/lib/components/ReactRRuleGenerator.js
+++ b/src/lib/components/ReactRRuleGenerator.js
@@ -4,6 +4,7 @@ import { cloneDeep, set } from 'lodash';
 
 import Repeat from './Repeat/index';
 import End from './End/index';
+import Start from './Start/index';
 import computeRRuleToString from '../utils/computeRRule/toString/computeRRule';
 import computeRRuleFromString from '../utils/computeRRule/fromString/computeRRule';
 import configureInitialState from '../utils/configureInitialState';
@@ -50,6 +51,7 @@ class ReactRRuleGenerator extends Component {
   render() {
     const {
       data: {
+        start,
         repeat,
         end,
         options,
@@ -63,28 +65,41 @@ class ReactRRuleGenerator extends Component {
         {
           !options.hideError && error && (
             <div className="alert alert-danger">
-              You provided an invalid RRule value to component. {`'${error.value}'`} is not a correct RRule string.
+              You provided an invalid RRule value to component. { `'${error.value}'` } is not a correct RRule string.
             </div>
           )
         }
 
         <div className="px-0 pt-3 border rounded">
 
+          {
+            !options.hideStart && (
+              <div>
+                <Start
+                  start={ start }
+                  handleChange={ this.handleChange }
+                />
+                <hr/>
+              </div>
+            )
+          }
+
           <div>
             <Repeat
-              repeat={repeat}
-              handleChange={this.handleChange}
+              repeat={ repeat }
+              handleChange={ this.handleChange }
             />
           </div>
 
-          <hr />
-
           {
             !options.hideEnd && (
-              <End
-                end={end}
-                handleChange={this.handleChange}
-              />
+              <div>
+                <hr/>
+                <End
+                  end={ end }
+                  handleChange={ this.handleChange }
+                />
+              </div>
             )
           }
 
@@ -100,6 +115,7 @@ ReactRRuleGenerator.propTypes = {
     yearly: PropTypes.oneOf(['on', 'on the']),
     monthly: PropTypes.oneOf(['on', 'on the']),
     end: PropTypes.arrayOf(PropTypes.oneOf(['Never', 'After', 'On date'])),
+    hideStart: PropTypes.bool,
     hideEnd: PropTypes.bool,
     hideError: PropTypes.bool,
     weekStartsOnSunday: PropTypes.bool,
@@ -110,7 +126,10 @@ ReactRRuleGenerator.propTypes = {
 };
 ReactRRuleGenerator.defaultProps = {
   value: '',
-  config: {},
+  config: {
+    // maintain backwards compatibility for UI by hiding new component by default
+    hideStart: true
+  },
   onChange() {},
   calendarComponent: null,
 };

--- a/src/lib/components/Start/OnDate.js
+++ b/src/lib/components/Start/OnDate.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+import DateTime from 'react-datetime';
+
+import 'moment/locale/en-gb';
+import 'moment/locale/en-ca';
+
+import { DATE_TIME_FORMAT } from '../../constants/index';
+
+const StartOnDate = ({
+                       onDate: {
+                         date,
+                         options,
+                       },
+                       handleChange,
+                     }) => {
+
+  const CustomCalendar = options.calendarComponent;
+  const locale = options.weekStartsOnSunday ? 'en-ca' : 'en-gb';
+  const calendarAttributes = {
+    'aria-label': 'Datetime picker for end on date',
+    value: date,
+    dateFormat: DATE_TIME_FORMAT,
+    locale,
+    readOnly: true,
+  };
+
+  return (
+    <div className="col-6 col-sm-3">
+      {
+        CustomCalendar
+          ? <CustomCalendar
+            { ...calendarAttributes }
+            onChange={ (event) => {
+              const editedEvent = {
+                target: {
+                  value: event.target.value,
+                  name: 'start.onDate.date',
+                },
+              };
+
+              handleChange(editedEvent);
+            } }
+          />
+          : <DateTime
+            { ...calendarAttributes }
+            inputProps={ { name: 'start.onDate.date', readOnly: true } }
+            timeFormat={ false }
+            viewMode="days"
+            closeOnSelect
+            closeOnTab
+            required
+            onChange={ (inputDate) => {
+              const editedEvent = {
+                target: {
+                  value: moment(inputDate).format(DATE_TIME_FORMAT),
+                  name: 'start.onDate.date',
+                },
+              };
+
+              handleChange(editedEvent);
+            } }
+          />
+      }
+    </div>
+  );
+};
+
+StartOnDate.propTypes = {
+  onDate: PropTypes.shape({
+    date: PropTypes.string.isRequired,
+    options: PropTypes.shape({
+      weekStartsOnSunday: PropTypes.bool,
+      calendarComponent: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
+    }).isRequired,
+  }).isRequired,
+  handleChange: PropTypes.func.isRequired,
+};
+
+export default StartOnDate;

--- a/src/lib/components/Start/index.js
+++ b/src/lib/components/Start/index.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import StartOnDate from './OnDate';
+
+const Start = ({
+                 start: {
+                   onDate,
+                   options,
+                 },
+                 handleChange,
+               }) => {
+
+  return (
+    <div className="px-3">
+      <div className="form-group row">
+        <div className="col-sm-2 text-sm-right">
+          <label
+            htmlFor="Start"
+            className="col-form-label"
+          >
+            <strong>
+              Start
+            </strong>
+          </label>
+        </div>
+        <StartOnDate onDate={ onDate } handleChange={ handleChange }/>
+      </div>
+    </div>
+  );
+};
+
+Start.propTypes = {
+  start: PropTypes.shape({
+    onDate: PropTypes.object.isRequired,
+  }).isRequired,
+  handleChange: PropTypes.func.isRequired,
+};
+
+export default Start;

--- a/src/lib/utils/computeRRule/fromString/computeRRule.js
+++ b/src/lib/utils/computeRRule/fromString/computeRRule.js
@@ -21,6 +21,7 @@ import computeDailyInterval from './computeDailyInterval';
 import computeHourlyInterval from './computeHourlyInterval';
 import computeEndMode from './computeEndMode';
 import computeEndAfter from './computeEndAfter';
+import computeStartOnDate from './computeStartOnDate';
 import computeEndOnDate from './computeEndOnDate';
 
 const computeRRule = (data, rrule) => {
@@ -34,6 +35,16 @@ const computeRRule = (data, rrule) => {
 
     newDataObj = {
       ...data,
+      start: {
+        ...data.start,
+        onDate: {
+          date: moment(computeStartOnDate(data, rruleObj)).format(DATE_TIME_FORMAT),
+          options: {
+            ...data.start.onDate.options,
+            weekStartsOnSunday: computeWeekStartDay(data, rruleObj),
+          },
+        },
+      },
       repeat: {
         ...data.repeat,
         frequency: computeFrequency(data, rruleObj),

--- a/src/lib/utils/computeRRule/fromString/computeStartOnDate.js
+++ b/src/lib/utils/computeRRule/fromString/computeStartOnDate.js
@@ -1,0 +1,7 @@
+const computeStartOnDate = (data, rruleObj) => {
+  if (!rruleObj.dtstart) {
+    return data.start.onDate.date;
+  }
+  return rruleObj.dtstart;
+};
+export default computeStartOnDate;

--- a/src/lib/utils/computeRRule/toString/computeRRule.js
+++ b/src/lib/utils/computeRRule/toString/computeRRule.js
@@ -1,11 +1,12 @@
 import RRule from 'rrule';
 
+import computeStart from './computeStart';
 import computeRepeat from './computeRepeat';
 import computeEnd from './computeEnd';
 import computeOptions from './computeOptions';
 
-const computeRRule = ({ repeat, end, options }) => {
-  const rruleObject = { ...computeRepeat(repeat), ...computeEnd(end), ...computeOptions(options) };
+const computeRRule = ({ start, repeat, end, options }) => {
+  const rruleObject = { ...computeStart(start), ...computeRepeat(repeat), ...computeEnd(end), ...computeOptions(options) };
   const rrule = new RRule(rruleObject);
   return rrule.toString();
 };

--- a/src/lib/utils/computeRRule/toString/computeStart.js
+++ b/src/lib/utils/computeRRule/toString/computeStart.js
@@ -1,0 +1,16 @@
+import moment from 'moment';
+
+const computeStart = ({ onDate: { date } }) => {
+  // verify that incoming date is valid
+  // by seeing if it can be converted into a moment object.
+  // if not, then create a new date
+  if (!moment.isMoment(moment(date))) {
+    date = new Date().setMilliseconds(0);
+  }
+
+  return {
+    dtstart: moment(date).toDate()
+  };
+};
+
+export default computeStart;

--- a/src/lib/utils/configureInitialState.js
+++ b/src/lib/utils/configureInitialState.js
@@ -4,12 +4,21 @@ import computeRRuleToString from './computeRRule/toString/computeRRule';
 import { DATE_TIME_FORMAT } from '../constants/index';
 
 const configureState = (config = {}, calendarComponent) => {
-  const configureFrequency = () => (config.repeat ? config.repeat[0] : 'Yearly');
-  const configureYearly = () => (config.yearly || 'on');
-  const configureMonthly = () => (config.monthly || 'on');
-  const configureEnd = () => (config.end ? config.end[0] : 'Never');
+  const configureFrequency = () => ( config.repeat ? config.repeat[0] : 'Yearly' );
+  const configureYearly = () => ( config.yearly || 'on' );
+  const configureMonthly = () => ( config.monthly || 'on' );
+  const configureEnd = () => ( config.end ? config.end[0] : 'Never' );
 
   const data = {
+    start: {
+      onDate: {
+        date: moment().format(DATE_TIME_FORMAT),
+        options: {
+          weekStartsOnSunday: config.weekStartsOnSunday,
+          calendarComponent,
+        },
+      },
+    },
     repeat: {
       frequency: configureFrequency(),
       yearly: {
@@ -81,6 +90,7 @@ const configureState = (config = {}, calendarComponent) => {
       },
     },
     options: {
+      hideStart: config.hideStart,
       hideEnd: config.hideEnd,
       hideError: config.hideError,
       weekStartsOnSunday: config.weekStartsOnSunday,


### PR DESCRIPTION
The current `ReactRRuleGenerator` component has no capacity to set the `dtstart` date for when a recurrence pattern begins.
This pull request includes the required components and logic for adding a datepicker to the `ReactRRuleGenerator` form for setting the recurrence start date.
This means that a recurrence pattern can be generated that does not start until the selected date.
To maintain backwards compatibility for anyone currently using the `ReactRRuleGenerator` component, a new `hideStart` config option has been added with a default value of `true` so that the new Start component will not suddenly appear unexpectedly in existing forms.
